### PR TITLE
Fix: Alternate Dialect Names

### DIFF
--- a/src/Interface/IDatabaseConfig.ts
+++ b/src/Interface/IDatabaseConfig.ts
@@ -4,5 +4,5 @@ export interface IDatabaseConfig {
     username?: string;
     password?: string;
     database: string;
-    dialect: 'pg' | 'sqlite';
+    dialect: 'pg' | 'sqlite' | string;
 }

--- a/src/snap.ts
+++ b/src/snap.ts
@@ -32,6 +32,7 @@ export class Snap {
         } else {
             this.dbConfig = config;
         }
+        this.dbConfig.dialect = this.parseDialect(this.dbConfig.dialect);
         switch (this.dbConfig.dialect) {
         case 'pg':
             this.db = new (require("./dialect/pg").default)(this.dbConfig)
@@ -42,6 +43,18 @@ export class Snap {
         default:
             throw new Error(`${this.dbConfig.dialect}: is not supported`);
         }
+    }
+
+    private parseDialect(dialect: string): string {
+        const dialectNames = {
+            'pg': ['postgres', 'pg'],
+            'sqlite': ['sqlite', 'sqlite3']
+        }
+        for (const key of Object.keys(dialectNames)) {
+            if (dialectNames[key].includes(dialect))
+                return key
+        }
+        throw new Error("Unknown Dialect");
     }
 
     public connect(): Promise<void> {


### PR DESCRIPTION
# Description

 - Fixes issue when using a database url
    (ex: postgres://postgres:postgres@db:5432/name, sql-snap didnt recognize postgres as a Dialect)